### PR TITLE
Support installing from packages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'beaker', '>= 3.9.0', {"groups"=>["system_tests"]}
 gem 'beaker-rspec', {"groups"=>["system_tests"]}
 gem 'beaker-module_install_helper', {"groups"=>["system_tests"]}
 gem 'beaker-puppet_install_helper', {"groups"=>["system_tests"]}
+gem 'beaker-docker'
 
 # rspec must be v2 for ruby 1.8.7
 if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -221,7 +221,7 @@ class netdata (
   Enum['save', 'map', 'ram','none']               $memory_mode          = 'save',
   Enum['none','single-threaded','multi-threaded'] $web_mode             = 'multi-threaded',
   Integer                                         $update_every         = 1,
-  String                                          $web_user             = $::netdata::params::web_user,
+  String                                          $web_user             = 'netdata',
   String                                          $web_group            = 'netdata',
   String                                          $user                 = 'netdata',
   String                                          $group                = 'netdata',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,12 +17,22 @@
 # * `history`
 #   Type:    Integer
 #   Default: 3600
-#   Desc:    The number of entries the netdata daemon will by default keep in memory for each chart dimension. 
+#   Desc:    The number of entries the netdata daemon will by default keep in memory for each chart dimension.
 #
 # * `install_dir`
 #   Type:    String
 #   Default: /opt/netdata
 #   Desc:    Path in which to deploy netdata locally.
+#
+# * `install_method`
+#   Type:    String
+#   Default: curl
+#   Desc:    Method to use to install netdata.  Options are 'curl' (default) and 'pkg'.
+#
+# * `package_names`
+#   Type:    Array
+#   Default: ['netdata']
+#   Desc:    Names of package(s) used to install netdata.  You need to take care of building packages and adding them to repos yourself
 #
 # * `config_dir`
 #   Type:    String
@@ -191,7 +201,9 @@ class netdata (
   String                                          $version              = 'latest',
   Optional[String]                                $hostname             = undef,
   Integer                                         $history              = 3600,
-  Stdlib::Absolutepath                            $install_dir          = '/opt/netdata',
+  Optional[Stdlib::Absolutepath]                  $install_dir          = '/opt/netdata',
+  Enum['curl', 'pkg']                             $install_method       = 'curl',
+  Array[String]                                   $package_names        = ['netdata'],
   Stdlib::Absolutepath                            $config_dir           = '/etc/netdata',
   Stdlib::Absolutepath                            $plugins_dir          = '/usr/libexec/netdata/plugins.d',
   Stdlib::Absolutepath                            $web_files_dir        = '/usr/share/netdata/web',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -221,7 +221,7 @@ class netdata (
   Enum['save', 'map', 'ram','none']               $memory_mode          = 'save',
   Enum['none','single-threaded','multi-threaded'] $web_mode             = 'multi-threaded',
   Integer                                         $update_every         = 1,
-  String                                          $web_user             = 'netdata',
+  String                                          $web_user             = $::netdata::params::web_user,
   String                                          $web_group            = 'netdata',
   String                                          $user                 = 'netdata',
   String                                          $group                = 'netdata',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,11 +2,21 @@
 class netdata::install {
 
   $install_dir          = $::netdata::install_dir
+  $install_method       = $::netdata::install_method
+  $package_names        = $::netdata::package_names
 
-  exec {'install':
-    path    => ['/bin','/sbin','/usr/bin','/usr/sbin'],
-    command => '/bin/bash -c \'bash <(curl -Ss https://my-netdata.io/kickstart-static64.sh) --dont-wait --dont-start-it\'',#lint:ignore:140chars
-    unless  => "ls ${install_dir}",
+  case $install_method {
+    'pkg': {
+      ensure_packages($package_names, {'ensure' => 'present'})
+    }
+    'curl': {
+      exec {'install':
+        path    => ['/bin','/sbin','/usr/bin','/usr/sbin'],
+        command => '/bin/bash -c \'bash <(curl -Ss https://my-netdata.io/kickstart-static64.sh) --dont-wait --dont-start-it\'',#lint:ignore:140chars
+        unless  => "ls ${install_dir}",
+      }
+    }
+    default: { fail('invalid install_method specified - should be \'curl\' or \'pkg\'') }
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,5 +37,4 @@ class netdata::params {
       fail("${::hostname}: This module does not support ${::osfamily} - ${::operatingsystem} ${::operatingsystemrelease}")
     }
   }
-
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,6 +3,7 @@ class netdata::service {
 
   $ensure               = $::netdata::ensure
   $install_dir          = $::netdata::install_dir
+  $install_method       = $::netdata::install_method
   $service_filepath     = $::netdata::service_filepath
   $service_filename     = $::netdata::service_filename
   $service_filesrc      = $::netdata::service_filesrc
@@ -19,9 +20,11 @@ class netdata::service {
     notify => Service['netdata'],
   }
 
-  file { "${service_filepath}/${service_filename}":
-    source => "${install_dir}/system/${service_filesrc}",
-    mode   => $service_filemode,
+  unless ($install_method == 'pkg') {
+    file { "${service_filepath}/${service_filename}":
+      source => "${install_dir}/system/${service_filesrc}",
+      mode   => $service_filemode,
+    }
   }
 
   service {'netdata':

--- a/manifests/uninstall.pp
+++ b/manifests/uninstall.pp
@@ -3,6 +3,8 @@ class netdata::uninstall {
 
   $service_filepath = $::netdata::service_filepath
   $service_filename = $::netdata::service_filename
+  $install_method   = $::netdata::install_method
+  $package_names    = $::netdata::package_names
   $netdata_cleanup = [
     '/etc/netdata',
     '/opt/netdata',
@@ -21,20 +23,28 @@ class netdata::uninstall {
     enable => false,
   }
 
-  file { $netdata_cleanup:
-    ensure  => 'absent',
-    force   => true,
-    require => Service['netdata'],
-  }
+  case $install_method {
+    'curl': {
+      file { $netdata_cleanup:
+        ensure  => 'absent',
+        force   => true,
+        require => Service['netdata'],
+      }
 
-  user { 'netdata':
-    ensure  => 'absent',
-    require => File[$netdata_cleanup],
-  }
+      user { 'netdata':
+        ensure  => 'absent',
+        require => File[$netdata_cleanup],
+      }
 
-  group { 'netdata':
-    ensure  => 'absent',
-    require => User['netdata'],
+      group { 'netdata':
+        ensure  => 'absent',
+        require => User['netdata'],
+      }
+    }
+    'pkg': {
+      ensure_packages($package_names, { 'ensure' => 'absent' } )
+    }
+    default: { fail('invalid install_method specified - should be \'curl\' or \'pkg\'') }
   }
 
 }

--- a/templates/netdata.conf.erb
+++ b/templates/netdata.conf.erb
@@ -25,7 +25,7 @@
   error log = <%= @error_log %>
   access log = <%= @access_log %>
 
-  web files user = <%= @web_user %>
+  web files owner = <%= @web_user %>
   web files group = <%= @web_group %>
   run as user = <%= @user %>
   default port = <%= @port %>


### PR DESCRIPTION
At present the module assumes that internet access is available. For systems without internet access we typically build RPMs for RHEL.

Added a few parameters to choose whether to install from packages (defaulting to the existing curl-based method), the names of the package(s) that need installing etc