### PR TITLE
alerting option with defaulting to no

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,6 +39,7 @@ class netdata::config {
   $registry_group       = $::netdata::registry_group
   $registry_allowfrom   = $::netdata::registry_allowfrom
   $streams              = $::netdata::streams
+  $alerting             = $::netdata::alerting
 
   File {
     ensure => $ensure,
@@ -65,6 +66,12 @@ class netdata::config {
     target  => "${config_dir}/stream.conf",
     content => template("${module_name}/stream.conf.erb"),
     order   => '01',
+  }
+
+  file_line {'SEND_EMAIL':
+    path  => '/opt/netdata/usr/lib/netdata/conf.d/health_alarm_notify.conf',
+    line  => "SEND_EMAIL=\"${alerting}\"",
+    match => '^SEND_EMAIL=\".*\"',
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -198,7 +198,7 @@
 class netdata (
 
   Enum['present', 'absent']                       $ensure               = 'present',
-  Enum['YES', 'NO']                       $alerting               = 'NO',
+  Enum['YES', 'NO']                               $alerting             = 'NO',
   String                                          $version              = 'latest',
   Optional[String]                                $hostname             = undef,
   Integer                                         $history              = 3600,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -198,6 +198,7 @@
 class netdata (
 
   Enum['present', 'absent']                       $ensure               = 'present',
+  Enum['YES', 'NO']                       $alerting               = 'NO',
   String                                          $version              = 'latest',
   Optional[String]                                $hostname             = undef,
   Integer                                         $history              = 3600,


### PR DESCRIPTION
Installing netdata on many machines could result with a lot of emails with alerts, so this is to disable such behavior by default.