### PR TITLE
manage unix_socket_dir if needed

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -54,6 +54,15 @@ class netdata::config {
     content => template("${module_name}/netdata.conf.erb"),
   }
 
+  if $::netdata::unix_socket_dir {
+    file { $::netdata::unix_socket_dir:
+      ensure => directory,
+      owner  => $user,
+      group  => $group,
+      mode   => '0750';
+    }
+  }
+
   concat { "${config_dir}/stream.conf":
     ensure  => $ensure,
     owner   => $user,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -174,6 +174,12 @@
 #   Default: 19999
 #   Desc:    Port configured on the remote registry.
 #
+# * `unix_socket_dir`
+#   Type:    Optional[Stdlib::Absolutepath
+#   Default: undef
+#   Desc:    Directory where the unix socket will be created
+#
+#
 # Examples
 # --------
 #
@@ -240,6 +246,7 @@ class netdata (
   Optional[String]                                $registry_allowfrom   = '*',
   Hash[String, Hash]                              $streams              = {},
   Hash[String, Hash]                              $web_log              = {},
+  Optional[Stdlib::Absolutepath]                  $unix_socket_dir      = undef,
 
 ) inherits ::netdata::params {
 


### PR DESCRIPTION
Using a unix socket is much more efficient (and secure) when running netdata behind a proxy.

With this PR, one can manage the socket dir creation if needed.